### PR TITLE
Fixing cpu -> util typo

### DIFF
--- a/starting.md
+++ b/starting.md
@@ -89,7 +89,7 @@ parameters. Below are some of the more commonly used flags:
     directs [logging output](/debugging/#logging-infrastructure) to `filename`
   * `-ll:cpu <int>`: CPU processors to create per process
   * `-ll:gpu <int>`: GPU processors to create per process
-  * `-ll:cpu <int>`: utility processors to create per process
+  * `-ll:util <int>`: utility processors to create per process
   * `-ll:csize <int>`: size of CPU DRAM memory per process (in MB)
   * `-ll:gsize <int>`: size of GASNet global memory available per process (in MB)
   * `-ll:rsize <int>`: size of GASNet registered RDMA memory available per process (in MB)


### PR DESCRIPTION
Fixing a typo where  -ll:cpu was listed twice instead of -ll:util